### PR TITLE
Update version to 0.2.7-fork-edx-1

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.7-dev+edx.1"
+__version__ = "0.2.7-fork-edx-1"


### PR DESCRIPTION
Fixes from problems regarding setuptools. The function `parse_version`
in the module `pkg_resources` uses a special ordering, such as:
- version 0.2.7-dev < 0.2.7
- version 0.2.7-f > 0.2.7

In addition, `parse_version` cannot parse versions that have `+` in
their identifiers.

To make our version work correctly we remove `-dev` and replace it with
`-fork` (starts with the letter f) and drop the use of `+`.
