### PR TITLE
Fixed intermittent test failure.

### DIFF
--- a/provider/oauth2/tests.py
+++ b/provider/oauth2/tests.py
@@ -579,7 +579,7 @@ class DeleteExpiredTest(BaseOAuth2TestCase):
         self.assertTrue('code' in location)
 
         # verify that Grant with code exists
-        code = urlparse.parse_qs(location)['code'][0]
+        code = urlparse.parse_qs(location.split('?')[1])['code'][0]
         self.assertTrue(Grant.objects.filter(code=code).exists())
 
         # use the code/grant


### PR DESCRIPTION
Depending on how python serialized out the query string (order
dependent), this would fail. This properly splits on the `?` so we only
parse the qs.

Otherwise, this was the result of this line:
`{'http://example.com/application/2/?state': ['abc'], 'code': ['fd553921a322fdc809a689b698c4f543d46dfee7']}`
