### PR TITLE
Support for response_type=token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ _build
 dist
 build
 venv
-/.project
-/.pydevproject

--- a/provider/oauth2/tests.py
+++ b/provider/oauth2/tests.py
@@ -48,9 +48,15 @@ class BaseOAuth2TestCase(TestCase):
     def get_password(self):
         return 'test'
 
+    def get_auth_params(self, response_type="code", **kwargs):
+        kwargs.setdefault("client_id", self.get_client().client_id)
+        if response_type:
+            kwargs["response_type"] = response_type
+        return kwargs
+
     def _login_and_authorize(self, url_func=None):
         if url_func is None:
-            url_func = lambda: self.auth_url() + '?client_id=%s&response_type=code&state=abc' % self.get_client().client_id
+            url_func = lambda: self.auth_url() + '?client_id={0}&response_type=code&state=abc'.format(self.get_client().client_id)
 
         response = self.client.get(url_func())
         response = self.client.get(self.auth_url2())
@@ -95,7 +101,7 @@ class AuthorizationTest(BaseOAuth2TestCase):
 
     def test_authorization_rejects_invalid_client_id(self):
         self.login()
-        response = self.client.get(self.auth_url() + '?client_id=123')
+        response = self.client.get(self.auth_url(), data={"client_id": 123})
         response = self.client.get(self.auth_url2())
 
         self.assertEqual(400, response.status_code)
@@ -103,7 +109,7 @@ class AuthorizationTest(BaseOAuth2TestCase):
 
     def test_authorization_requires_response_type(self):
         self.login()
-        response = self.client.get(self.auth_url() + '?client_id=%s' % self.get_client().client_id)
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(response_type=None))
         response = self.client.get(self.auth_url2())
 
         self.assertEqual(400, response.status_code)
@@ -112,45 +118,112 @@ class AuthorizationTest(BaseOAuth2TestCase):
     def test_authorization_requires_supported_response_type(self):
         self.login()
         response = self.client.get(
-            self.auth_url() + '?client_id=%s&response_type=unsupported' % self.get_client().client_id)
+            self.auth_url(), self.get_auth_params(response_type="unsupported"))
         response = self.client.get(self.auth_url2())
 
         self.assertEqual(400, response.status_code)
         self.assertTrue(escape(u"'unsupported' is not a supported response type.") in response.content)
 
-        response = self.client.get(self.auth_url() + '?client_id=%s&response_type=code' % self.get_client().client_id)
+        response = self.client.get(self.auth_url(), data=self.get_auth_params())
         response = self.client.get(self.auth_url2())
         self.assertEqual(200, response.status_code, response.content)
 
-        # Token authorization redirects to redirect_uri
-        response = self.client.get(self.auth_url() + '?client_id=%s&response_type=token' % self.get_client().client_id)
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
         response = self.client.get(self.auth_url2())
-        self.assertEqual(302, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_token_authorization_redirects_to_correct_uri(self):
         self.login()
 
-        self.client.get(self.auth_url() + '?client_id=%s&response_type=token' % self.get_client().client_id)
-        response = self.client.get(self.auth_url2())
-        self.assertEqual(302, response.status_code)
-        url, fragment = response.get('location').split('#')
+        response1 = self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"), follow=True)
+
+        # confirm the resulting "do you agree" section.
+        # We can skip the csrf mapping during tests.
+        response2 = self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(302, response2.status_code)
+        url, fragment = response2.get('location').split('#')
         self.assertEqual(url, self.get_client().redirect_uri)
         self.assertTrue('access_token' in urlparse.parse_qs(fragment))
 
+    def test_token_ignores_expired_tokens(self):
+        constants.SINGLE_ACCESS_TOKEN = True
+        AccessToken.objects.create(
+            user=self.get_user(),
+            client=self.get_client(),
+            expires=date_now() - datetime.timedelta(days=1),
+        )
+
+        self.login()
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(AccessToken.objects.count(), 2)
+        constants.SINGLE_ACCESS_TOKEN = False
+
+    def test_token_doesnt_return_tokens_from_another_client(self):
+        constants.SINGLE_ACCESS_TOKEN = True
+
+        # Different client than we'll be submitting an RPC for.
+        AccessToken.objects.create(
+            user=self.get_user(),
+            client=Client.objects.get(pk=1)
+        )
+
+        self.login()
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(AccessToken.objects.count(), 2)
+        constants.SINGLE_ACCESS_TOKEN = False
+
+    def test_token_authorization_respects_single_access_token_constant(self):
+        constants.SINGLE_ACCESS_TOKEN = True
+        self.login()
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(AccessToken.objects.count(), 1)
+
+        # Second request.
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(AccessToken.objects.count(), 1)
+        constants.SINGLE_ACCESS_TOKEN = False
+
+    def test_token_authorization_can_do_multi_access_tokens(self):
+        constants.SINGLE_ACCESS_TOKEN = False
+        self.login()
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(AccessToken.objects.count(), 1)
+
+        # Second request.
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2(), data={'authorize': 'Authorize'})
+
+        self.assertEqual(AccessToken.objects.count(), 2)
+
+    def test_token_authorization_cancellation(self):
+        constants.SINGLE_ACCESS_TOKEN = False
+        self.login()
+        self.client.get(self.auth_url(), data=self.get_auth_params(response_type="token"))
+        self.client.post(self.auth_url2())
+
+        self.assertEqual(AccessToken.objects.count(), 0)
+        
     def test_authorization_requires_a_valid_redirect_uri(self):
         self.login()
 
-        response = self.client.get(self.auth_url() + '?client_id=%s&response_type=code&redirect_uri=%s' % (
-            self.get_client().client_id,
-            self.get_client().redirect_uri + '-invalid'))
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(redirect_uri=self.get_client().redirect_uri + '-invalid'))
         response = self.client.get(self.auth_url2())
 
         self.assertEqual(400, response.status_code)
         self.assertTrue(escape(u"The requested redirect didn't match the client settings.") in response.content)
 
-        response = self.client.get(self.auth_url() + '?client_id=%s&response_type=code&redirect_uri=%s' % (
-            self.get_client().client_id,
-            self.get_client().redirect_uri))
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(redirect_uri=self.get_client().redirect_uri))
         response = self.client.get(self.auth_url2())
 
         self.assertEqual(200, response.status_code)
@@ -158,32 +231,25 @@ class AuthorizationTest(BaseOAuth2TestCase):
     def test_authorization_requires_a_valid_scope(self):
         self.login()
 
-        response = self.client.get(
-            self.auth_url() + '?client_id=%s&response_type=code&scope=invalid+invalid2' % self.get_client().client_id)
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(scope="invalid"))
         response = self.client.get(self.auth_url2())
 
         self.assertEqual(400, response.status_code)
-        self.assertTrue(escape(u"'invalid' is not a valid scope.") in response.content)
+        self.assertTrue(escape(u"'invalid' is not a valid scope.") in response.content, 'Expected `{0}` in {1}'.format(escape(u"'invalid' is not a valid scope."), response.content))
 
-        response = self.client.get(self.auth_url() + '?client_id=%s&response_type=code&scope=%s' % (
-            self.get_client().client_id,
-            constants.SCOPES[0][1]))
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(scope=constants.SCOPES[0][1]))
         response = self.client.get(self.auth_url2())
         self.assertEqual(200, response.status_code)
 
     def test_authorization_is_not_granted(self):
         self.login()
 
-        response = self.client.get(self.auth_url() + '?client_id=%s&response_type=code' % self.get_client().client_id)
+        response = self.client.get(self.auth_url(), data=self.get_auth_params(response_type="code"))
         response = self.client.get(self.auth_url2())
 
         response = self.client.post(self.auth_url2(), {'authorize': False, 'scope': constants.SCOPES[0][1]})
         self.assertEqual(302, response.status_code, response.content)
-        self.assertTrue(self.redirect_url() in response['Location'])
-
-        response = self.client.get(self.redirect_url())
-
-        self.assertEqual(302, response.status_code)
+        self.assertTrue(self.get_client().redirect_uri in response['Location'], '{0} not in {1}'.format(self.redirect_url(), response['Location']))
         self.assertTrue('error=access_denied' in response['Location'])
         self.assertFalse('code' in response['Location'])
 
@@ -590,7 +656,7 @@ class DeleteExpiredTest(BaseOAuth2TestCase):
         self.assertTrue('code' in location)
 
         # verify that Grant with code exists
-        code = urlparse.parse_qs(location.split('?')[1])['code'][0]
+        code = urlparse.parse_qs(urlparse.urlparse(location).query)['code'][0]
         self.assertTrue(Grant.objects.filter(code=code).exists())
 
         # use the code/grant

--- a/provider/views.py
+++ b/provider/views.py
@@ -478,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token, data=None):
+    def access_token_response(self, access_token):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.

--- a/provider/views.py
+++ b/provider/views.py
@@ -478,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token):
+    def access_token_response(self, access_token, data=None):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.

--- a/provider/views.py
+++ b/provider/views.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic.base import TemplateView
 from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
+from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
 
 
@@ -261,11 +262,22 @@ class Authorize(OAuthView, Mixin):
         authorization_form = self.get_authorization_form(request, client,
             post_data, data)
 
-        if not authorization_form.is_bound or not authorization_form.is_valid():
-            return self.render_to_response({
-                'client': client,
-                'form': authorization_form,
-                'oauth_data': data, })
+        if data.get('response_type', None):
+            if data.get('response_type') == 'code':                
+                if not authorization_form.is_bound \
+                    or not authorization_form.is_valid():
+                    return self.render_to_response({
+                                                    'client': client,
+                                                    'form': authorization_form,
+                                                    'oauth_data': data, })
+            #implements the 'implicit grant'
+            elif data.get('response_type') == 'token':
+                #uses request.user as the urls.py already required login_required
+                atm = AccessTokenModel.objects.create(user=request.user,
+                                                client=client,
+                                                scope=data.get('scope'))
+                at = AccessToken()
+                return at.access_token_response(atm)
 
         code = self.save_authorization(request, client,
             authorization_form, data)

--- a/provider/views.py
+++ b/provider/views.py
@@ -499,13 +499,6 @@ class AccessToken(OAuthView, Mixin):
         except ObjectDoesNotExist:
             pass
 
-        if data.get('response_type') == 'token':
-            if len(data.get('state', '')) > 0:
-                response_data['state'] = data.get('state')
-            path = "%s?%s" % (data.get('redirect_uri'), 
-                              urlencode(response_data))                       
-            return HttpResponseRedirect(path)
-
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'
         )

--- a/provider/views.py
+++ b/provider/views.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic.base import TemplateView
 from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
+from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
 
 
@@ -261,11 +262,22 @@ class Authorize(OAuthView, Mixin):
         authorization_form = self.get_authorization_form(request, client,
             post_data, data)
 
-        if not authorization_form.is_bound or not authorization_form.is_valid():
-            return self.render_to_response({
-                'client': client,
-                'form': authorization_form,
-                'oauth_data': data, })
+        if data.get('response_type', None):
+            if data.get('response_type') == 'code':                
+                if not authorization_form.is_bound \
+                    or not authorization_form.is_valid():
+                    return self.render_to_response({
+                                                    'client': client,
+                                                    'form': authorization_form,
+                                                    'oauth_data': data, })
+            #implements the 'implicit grant'
+            elif data.get('response_type') == 'token':
+                #uses request.user as the urls.py already required login_required
+                atm = AccessTokenModel.objects.create(user=request.user,
+                                                client=client,
+                                                scope=data.get('scope'))
+                at = AccessToken()
+                return at.access_token_response(atm, data)
 
         code = self.save_authorization(request, client,
             authorization_form, data)
@@ -466,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token):
+    def access_token_response(self, access_token, data=None):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.
@@ -486,6 +498,13 @@ class AccessToken(OAuthView, Mixin):
             response_data['refresh_token'] = rt.token
         except ObjectDoesNotExist:
             pass
+
+        if data.get('response_type') == 'token':
+            if len(data.get('state', '')) > 0:
+                response_data['state'] = data.get('state')
+            path = "%s?%s" % (data.get('redirect_uri'), 
+                              urlencode(response_data))                       
+            return HttpResponseRedirect(path)
 
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'

--- a/provider/views.py
+++ b/provider/views.py
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext as _
 from django.views.generic.base import TemplateView
 from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
-from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
 
 
@@ -262,22 +261,11 @@ class Authorize(OAuthView, Mixin):
         authorization_form = self.get_authorization_form(request, client,
             post_data, data)
 
-        if data.get('response_type', None):
-            if data.get('response_type') == 'code':                
-                if not authorization_form.is_bound \
-                    or not authorization_form.is_valid():
-                    return self.render_to_response({
-                                                    'client': client,
-                                                    'form': authorization_form,
-                                                    'oauth_data': data, })
-            #implements the 'implicit grant'
-            elif data.get('response_type') == 'token':
-                #uses request.user as the urls.py already required login_required
-                atm = AccessTokenModel.objects.create(user=request.user,
-                                                client=client,
-                                                scope=data.get('scope'))
-                at = AccessToken()
-                return at.access_token_response(atm, data)
+        if not authorization_form.is_bound or not authorization_form.is_valid():
+            return self.render_to_response({
+                'client': client,
+                'form': authorization_form,
+                'oauth_data': data, })
 
         code = self.save_authorization(request, client,
             authorization_form, data)
@@ -478,7 +466,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token, data=None):
+    def access_token_response(self, access_token):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.
@@ -498,13 +486,6 @@ class AccessToken(OAuthView, Mixin):
             response_data['refresh_token'] = rt.token
         except ObjectDoesNotExist:
             pass
-
-        if data.get('response_type') == 'token':
-            if len(data.get('state', '')) > 0:
-                response_data['state'] = data.get('state')
-            path = "%s?%s" % (data.get('redirect_uri'), 
-                              urlencode(response_data))                       
-            return HttpResponseRedirect(path)
 
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'

--- a/provider/views.py
+++ b/provider/views.py
@@ -277,7 +277,7 @@ class Authorize(OAuthView, Mixin):
                                                 client=client,
                                                 scope=data.get('scope'))
                 at = AccessToken()
-                return at.access_token_response(atm)
+                return at.access_token_response(atm, data)
 
         code = self.save_authorization(request, client,
             authorization_form, data)

--- a/provider/views.py
+++ b/provider/views.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
 from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
+from django.utils.http import urlencode
 
 
 class OAuthError(Exception):

--- a/provider/views.py
+++ b/provider/views.py
@@ -499,10 +499,13 @@ class AccessToken(OAuthView, Mixin):
         except ObjectDoesNotExist:
             pass
 
-        if data.get('response_type') == 'token':
+        if data is not None and data.get('response_type') == 'token':
+            basepath = data.get("redirect_uri")
+            if not basepath:
+                basepath = access_token.client.redirect_uri
             if len(data.get('state', '')) > 0:
                 response_data['state'] = data.get('state')
-            path = "%s?%s" % (data.get('redirect_uri'), 
+            path = "%s#%s" % (basepath, 
                               urlencode(response_data))                       
             return HttpResponseRedirect(path)
 

--- a/provider/views.py
+++ b/provider/views.py
@@ -277,7 +277,7 @@ class Authorize(OAuthView, Mixin):
                                                 client=client,
                                                 scope=data.get('scope'))
                 at = AccessToken()
-                return at.access_token_response(atm, data)
+                return at.access_token_response(atm)
 
         code = self.save_authorization(request, client,
             authorization_form, data)

--- a/provider/views.py
+++ b/provider/views.py
@@ -478,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token, data=None):
+    def access_token_response(self, access_token):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.
@@ -498,13 +498,6 @@ class AccessToken(OAuthView, Mixin):
             response_data['refresh_token'] = rt.token
         except ObjectDoesNotExist:
             pass
-
-        if data.get('response_type') == 'token':
-            if len(data.get('state', '')) > 0:
-                response_data['state'] = data.get('state')
-            path = "%s?%s" % (data.get('redirect_uri'), 
-                              urlencode(response_data))                       
-            return HttpResponseRedirect(path)
 
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'


### PR DESCRIPTION
# Overview

This change adds support for implicit grant oauth status. This change is necessary to support browser-only OAuth clients, which we'll be making use of as part of some CCX work at MIT's ODL. This does not remove functionality, but rather provides another avenue for OAuth2 clients.
# Manual testing

You should be able to issue a request to the following URL (note that you'll need to update the client_id and redirect_uri to match what's on your local system). The result should redirect you to localhost:9001 with a URL fragment containing the access token.

http://localhost:8000/oauth2/authorize/?client_id=015c91a76033cac3040d&redirect_uri=localhost:9001&response_type=token

Example result: http://localhost:9001/#access_token=a16051276d052616bcb2f87e71974aaedab9bdfa&token_type=Bearer&expires_in=2591999&scope=
# Background

This is mostly code from https://github.com/caffeinehit/django-oauth2-provider/pull/59 with the exception of a few tests that I wrote.

It relies on #13.

I've not communicated with the greater edX team about this work in particular and there is no backing JIRA ticket.
