### PR TITLE
Updated README to point to edx's fork in travis.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 django-oauth2-provider
 ======================
 
-.. image:: https://travis-ci.org/caffeinehit/django-oauth2-provider.png?branch=master
+.. image:: https://travis-ci.org/edx/django-oauth2-provider.svg?branch=edx
+    :target: https://travis-ci.org/edx/django-oauth2-provider
 
 *django-oauth2-provider* is a Django application that provides
 customizable OAuth2\-authentication for your Django projects.


### PR DESCRIPTION
We are running tests in travis, but the original build status badge isn't pointed at that repo. This is pointed at the edx branch, which is set as the repo's default branch.

https://travis-ci.org/edx/django-oauth2-provider
