### PR TITLE
Extend Django support to 2.1.* series.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
-    install_requires=['shortuuid>=0.4.3,<1.0.0', 'Django>=1.11,<2.1'],
+    install_requires=['shortuuid>=0.4.3,<1.0.0', 'Django>=1.11,<2.2'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
-envlist = py{27,35,36}-django{111},py{35,36,37}-django{20}
+envlist = py{27,35,36}-django{111},py{35,36,37}-django{20,21}
 
 [testenv]
 deps =
     -r{toxinidir}/requirements/requirements-test.txt
     django111: Django>=1.11,<2
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
 commands =
     coverage run --branch --source=provider manage.py test provider provider.oauth2
     coverage report
-    py{27,35,36}-django{111},py{35,36,37}-django{20}: python manage.py migrate --run-syncdb
-    py{27,35,36}-django{111},py{35,36,37}-django{20}: python manage.py makemigrations --check --dry-run
+    py{27,35,36}-django{111},py{35,36,37}-django{20,21}: python manage.py migrate --run-syncdb
+    py{27,35,36}-django{111},py{35,36,37}-django{20,21}: python manage.py makemigrations --check --dry-run


### PR DESCRIPTION
Hi!

We wanted to upgrade our Django to the latest version (2.1.*) and found that we bounded with this package by explicit 'Django>=1.11,<2.1' requirement. So here is the PR.

Also updated "Programming Language :: Python" section for 3.7 version since it the support was added (https://github.com/edx/django-oauth2-provider/pull/55).

Have a good day!